### PR TITLE
fix: support v2 gateway descriptors

### DIFF
--- a/.changeset/modern-gateway-session.md
+++ b/.changeset/modern-gateway-session.md
@@ -1,0 +1,5 @@
+---
+"grok-bot-cli": patch
+---
+
+Support version 2 Grok Bot gateway descriptors and report unusable app sessions clearly in `gbot doctor`.

--- a/src/app-session.js
+++ b/src/app-session.js
@@ -6,6 +6,49 @@ import { join } from "node:path";
 
 const SAFE_STORAGE_PREFIX = Buffer.from("v10");
 
+export class GrokBotGatewaySessionError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "GrokBotGatewaySessionError";
+    this.code = code;
+  }
+}
+
+function encryptedPayload(wrapped) {
+  if (wrapped.version != null && wrapped.version !== 1 && wrapped.version !== 2) {
+    throw new GrokBotGatewaySessionError(
+      "UNSUPPORTED_VERSION",
+      `Unsupported Grok Bot gateway descriptor version ${wrapped.version}.`,
+    );
+  }
+  let encrypted;
+  if (wrapped.version === 2) {
+    const entries = Object.values(wrapped.entries ?? {});
+    if (entries.length === 0) {
+      throw new GrokBotGatewaySessionError(
+        "EMPTY_ENTRIES",
+        "Grok Bot gateway descriptor has no saved gateway entries.",
+      );
+    }
+    if (entries.length > 1) {
+      throw new GrokBotGatewaySessionError(
+        "AMBIGUOUS_ENTRIES",
+        "Grok Bot gateway descriptor has multiple saved gateway entries and no active entry selection.",
+      );
+    }
+    encrypted = entries[0]?.encrypted;
+  } else {
+    encrypted = wrapped.encrypted;
+  }
+  if (typeof encrypted !== "string" || !encrypted) {
+    throw new GrokBotGatewaySessionError(
+      "MISSING_ENCRYPTED_PAYLOAD",
+      "Grok Bot gateway descriptor is missing an encrypted payload.",
+    );
+  }
+  return encrypted;
+}
+
 export function decryptSafeStorageString(encryptedBase64, password) {
   const encrypted = Buffer.from(encryptedBase64, "base64");
   if (!encrypted.subarray(0, 3).equals(SAFE_STORAGE_PREFIX)) {
@@ -57,13 +100,17 @@ export function loadGrokBotGatewaySession({
   if (!existsSync(path)) return null;
 
   const wrapped = JSON.parse(readFileSync(path, "utf8"));
+  const encrypted = encryptedPayload(wrapped);
   const clear = decryptSafeStorageString(
-    wrapped.encrypted,
+    encrypted,
     getKeychainPassword(),
   );
   const descriptor = JSON.parse(clear);
   if (!descriptor.baseUrl || !descriptor.token) {
-    throw new Error("Grok Bot gateway descriptor is incomplete.");
+    throw new GrokBotGatewaySessionError(
+      "INCOMPLETE_DESCRIPTOR",
+      "Decrypted Grok Bot gateway descriptor is incomplete.",
+    );
   }
 
   return {
@@ -71,4 +118,21 @@ export function loadGrokBotGatewaySession({
     gatewayToken: String(descriptor.token),
     headers: descriptor.headers ?? {},
   };
+}
+
+export function inspectGrokBotGatewaySession(options = {}) {
+  if (!hasGrokBotGatewaySession(options)) {
+    return { present: false, usable: false };
+  }
+  try {
+    loadGrokBotGatewaySession(options);
+    return { present: true, usable: true };
+  } catch (error) {
+    return {
+      present: true,
+      usable: false,
+      code: error instanceof GrokBotGatewaySessionError ? error.code : "UNUSABLE_SESSION",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@
 import { AVATAR_COLORS, AVATAR_SHAPES, MAX_GROUP_MEMBERS, StoreError, defaultCandidateRoots, looksLikeAgentsRoot, resolveAgentsRoot } from "./store.js";
 import { hasGatewayAuth } from "./gateway.js";
 import { openBackend } from "./commands.js";
+import { inspectGrokBotGatewaySession } from "./app-session.js";
 
 function print(value) {
   if (typeof value === "string") process.stdout.write(value + "\n");
@@ -247,11 +248,16 @@ async function main(argv) {
       if (!(err instanceof StoreError)) throw err;
     }
     const note = "Live roster is on the box. Prefer CURSOR_ACCESS_TOKEN then EnsureSandBox then POST gateway /api/*.";
-    const payload = { resolved, found, candidates, gatewayAuthPresent: hasGatewayAuth(), note };
+    const gatewayAuthPresent = hasGatewayAuth();
+    const grokBotAppSession = inspectGrokBotGatewaySession();
+    const payload = { resolved, found, candidates, gatewayAuthPresent, grokBotAppSession, note };
     if (json) print(payload);
     else {
       print("resolved: " + (resolved ?? "(none)"));
-      print("gateway auth: " + (hasGatewayAuth() ? "yes (env)" : "no"));
+      print("gateway auth: " + (gatewayAuthPresent ? "present" : "no"));
+      if (grokBotAppSession.usable) print("Grok Bot app session: usable");
+      else if (grokBotAppSession.present) print("Grok Bot app session: present but unusable: " + grokBotAppSession.error);
+      else print("Grok Bot app session: not found");
       print("found:");
       print(found.length ? found.map((p) => "  " + p).join("\n") : "  (none)");
       print("candidates:");

--- a/test/app-session.test.js
+++ b/test/app-session.test.js
@@ -6,11 +6,25 @@ import test from "node:test";
 
 import {
   decryptSafeStorageString,
+  inspectGrokBotGatewaySession,
   loadGrokBotGatewaySession,
 } from "../src/app-session.js";
 
 const ENCRYPTED_DESCRIPTOR =
   "djEwddBm+U69UF2IJtIUtedNqMB3bQt7HsRw7MLWRkw/IfnMK+c4czCXq82JKPNsdsP3Bp2fX8HoGPZFsa7k+JOmbIkBanQwl4yiy9v7iOA+mE4rtGqYbYD9jJc+/9YnhcGjvSxCxD8fKbJLbHifTwroGQ==";
+const ENCRYPTED_INCOMPLETE_DESCRIPTOR =
+  "djEwddBm+U69UF2IJtIUtedNqMB3bQt7HsRw7MLWRkw/IfnWb2TrPAofoKysOC2KnKLJ";
+
+function writeWrappedDescriptor(wrapped) {
+  const home = mkdtempSync(join(tmpdir(), "gbot-home-"));
+  const descriptorPath = join(
+    home,
+    "Library/Application Support/Grok Bot/gateway-descriptor.json",
+  );
+  mkdirSync(dirname(descriptorPath), { recursive: true });
+  writeFileSync(descriptorPath, JSON.stringify(wrapped));
+  return home;
+}
 
 test("decrypts an Electron Safe Storage v10 string", () => {
   const clear = decryptSafeStorageString(
@@ -47,6 +61,152 @@ test("loads the signed-in Grok Bot gateway without manual tokens", () => {
     gatewayUrl: "https://box.example",
     gatewayToken: "gateway-token",
     headers: { "x-anyrun-network-token": "route-token" },
+  });
+});
+
+test("loads a version 2 Grok Bot gateway entry", () => {
+  const home = writeWrappedDescriptor({
+    version: 2,
+    entries: {
+      primary: {
+        encrypted: ENCRYPTED_DESCRIPTOR,
+        savedAtMs: 1_787_000_000_000,
+      },
+    },
+  });
+
+  const session = loadGrokBotGatewaySession({
+    platform: "darwin",
+    home,
+    getKeychainPassword: () => "demo-password",
+  });
+
+  assert.deepEqual(session, {
+    gatewayUrl: "https://box.example",
+    gatewayToken: "gateway-token",
+    headers: { "x-anyrun-network-token": "route-token" },
+  });
+});
+
+test("rejects a version 2 descriptor with no entries", () => {
+  const home = writeWrappedDescriptor({ version: 2, entries: {} });
+
+  assert.throws(
+    () => loadGrokBotGatewaySession({
+      platform: "darwin",
+      home,
+      getKeychainPassword: () => "demo-password",
+    }),
+    (error) => {
+      assert.equal(error.name, "GrokBotGatewaySessionError");
+      assert.equal(error.code, "EMPTY_ENTRIES");
+      assert.match(error.message, /no saved gateway entries/i);
+      return true;
+    },
+  );
+});
+
+test("rejects a version 2 descriptor with ambiguous entries", () => {
+  const home = writeWrappedDescriptor({
+    version: 2,
+    entries: {
+      first: { encrypted: ENCRYPTED_DESCRIPTOR, savedAtMs: 1 },
+      second: { encrypted: ENCRYPTED_DESCRIPTOR, savedAtMs: 2 },
+    },
+  });
+
+  assert.throws(
+    () => loadGrokBotGatewaySession({
+      platform: "darwin",
+      home,
+      getKeychainPassword: () => "demo-password",
+    }),
+    (error) => {
+      assert.equal(error.name, "GrokBotGatewaySessionError");
+      assert.equal(error.code, "AMBIGUOUS_ENTRIES");
+      assert.match(error.message, /multiple saved gateway entries/i);
+      return true;
+    },
+  );
+});
+
+test("rejects a gateway entry without an encrypted payload", () => {
+  const home = writeWrappedDescriptor({
+    version: 2,
+    entries: { primary: { savedAtMs: 1 } },
+  });
+
+  assert.throws(
+    () => loadGrokBotGatewaySession({
+      platform: "darwin",
+      home,
+      getKeychainPassword: () => "demo-password",
+    }),
+    (error) => {
+      assert.equal(error.name, "GrokBotGatewaySessionError");
+      assert.equal(error.code, "MISSING_ENCRYPTED_PAYLOAD");
+      assert.match(error.message, /missing an encrypted payload/i);
+      return true;
+    },
+  );
+});
+
+test("rejects an unsupported gateway descriptor version", () => {
+  const home = writeWrappedDescriptor({
+    version: 3,
+    encrypted: ENCRYPTED_DESCRIPTOR,
+  });
+
+  assert.throws(
+    () => loadGrokBotGatewaySession({
+      platform: "darwin",
+      home,
+      getKeychainPassword: () => "demo-password",
+    }),
+    (error) => {
+      assert.equal(error.name, "GrokBotGatewaySessionError");
+      assert.equal(error.code, "UNSUPPORTED_VERSION");
+      assert.match(error.message, /unsupported .*gateway descriptor version 3/i);
+      return true;
+    },
+  );
+});
+
+test("rejects an incomplete decrypted gateway descriptor", () => {
+  const home = writeWrappedDescriptor({
+    version: 2,
+    entries: { primary: { encrypted: ENCRYPTED_INCOMPLETE_DESCRIPTOR } },
+  });
+
+  assert.throws(
+    () => loadGrokBotGatewaySession({
+      platform: "darwin",
+      home,
+      getKeychainPassword: () => "demo-password",
+    }),
+    (error) => {
+      assert.equal(error.name, "GrokBotGatewaySessionError");
+      assert.equal(error.code, "INCOMPLETE_DESCRIPTOR");
+      assert.match(error.message, /decrypted .*gateway descriptor is incomplete/i);
+      return true;
+    },
+  );
+});
+
+test("reports a present but unusable Grok Bot app session", () => {
+  const home = writeWrappedDescriptor({ version: 2, entries: {} });
+
+  const status = inspectGrokBotGatewaySession({
+    platform: "darwin",
+    home,
+    getKeychainPassword: () => "demo-password",
+  });
+
+  assert.deepEqual(status, {
+    present: true,
+    usable: false,
+    code: "EMPTY_ENTRIES",
+    error: "Grok Bot gateway descriptor has no saved gateway entries.",
   });
 });
 

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const CLI = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+
+test("doctor reports a present but unusable Grok Bot app session", () => {
+  const home = mkdtempSync(join(tmpdir(), "gbot-doctor-home-"));
+  const descriptorPath = join(
+    home,
+    "Library/Application Support/Grok Bot/gateway-descriptor.json",
+  );
+  mkdirSync(dirname(descriptorPath), { recursive: true });
+  writeFileSync(descriptorPath, JSON.stringify({ version: 2, entries: {} }));
+  const env = { ...process.env, HOME: home };
+  for (const name of [
+    "CURSOR_ACCESS_TOKEN",
+    "GROK_BOT_ACCESS_TOKEN",
+    "GROK_BOT_GATEWAY_URL",
+    "GROK_BOT_GATEWAY_TOKEN",
+    "SAND_ACCESS_TOKEN",
+    "SAND_HOST_GATEWAY_URL",
+    "SAND_HOST_GATEWAY_TOKEN",
+    "SAND_GATEWAY_TOKEN",
+  ]) delete env[name];
+
+  const result = spawnSync(process.execPath, [CLI, "--json", "doctor"], {
+    encoding: "utf8",
+    env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.deepEqual(payload.grokBotAppSession, {
+    present: true,
+    usable: false,
+    code: "EMPTY_ENTRIES",
+    error: "Grok Bot gateway descriptor has no saved gateway entries.",
+  });
+});


### PR DESCRIPTION
## Summary

- load both legacy top-level and version 2 entry-based Grok Bot gateway descriptors
- return typed, friendly errors for empty, ambiguous, missing, incomplete, and unsupported descriptor states
- make `gbot doctor` distinguish a usable app session from a descriptor that is only present
- include a patch Changeset for the npm release

## Verification

- RED: v2 fixture reproduced `Buffer.from(... Received undefined)` through `wrapped.encrypted`
- GREEN: `npm test` — 24/24 pass
- `npx --yes publint@0.3.24` — All good
- actionlint — 0 errors in 2 workflows
- gitleaks — no leaks found
- packed consumer CLI — v2 app session usable; token-free auto-auth listed 42 records

No real tokens, descriptors, or Bearer headers are included in tests or output.