### PR TITLE
test: limit app-session doctor integration to macOS

### DIFF
--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -8,7 +8,9 @@ import test from "node:test";
 
 const CLI = fileURLToPath(new URL("../src/cli.js", import.meta.url));
 
-test("doctor reports a present but unusable Grok Bot app session", () => {
+test("doctor reports a present but unusable Grok Bot app session", {
+  skip: process.platform !== "darwin" && "Grok Bot app sessions are macOS-only",
+}, () => {
   const home = mkdtempSync(join(tmpdir(), "gbot-doctor-home-"));
   const descriptorPath = join(
     home,


### PR DESCRIPTION
The spawned CLI integration test relies on the macOS-only Grok Bot app-session path. On Linux CI, the production platform guard correctly reports the session as absent.

This marks only that integration test macOS-only; the injected-platform unit coverage for v2 loading and every typed error still runs on Linux.

- Local macOS suite: 24/24 pass
- publint: All good
- No package Changeset: test-only correction